### PR TITLE
Added peep indicator to record cards

### DIFF
--- a/src/app/components/record-card/record-card.component.html
+++ b/src/app/components/record-card/record-card.component.html
@@ -1,12 +1,15 @@
 <ion-item button lines="inset" *ngIf="record">
   <ion-avatar slot="start">
+    <div
+      class="peep-status"
+      [ngClass]="{ 'peep-due': record.loanDue, 'peep-active': !record.loanDue }"
+    ></div>
     <img [src]="avatar" />
   </ion-avatar>
   <ion-label>
     <h2>{{ record?.name }}</h2>
     <h4>
       {{ record?.fCreateDate }}
-      <span><ion-icon slot="start" name="add"></ion-icon></span>
     </h4>
   </ion-label>
 

--- a/src/app/components/record-card/record-card.component.scss
+++ b/src/app/components/record-card/record-card.component.scss
@@ -1,0 +1,14 @@
+.peep-status {
+	height: 100%;
+	left: 6px;
+	position: absolute;
+	width: 3px;
+}
+
+.peep-due {
+	background: rgb(255, 0, 0);
+}
+
+.peep-active {
+	background: rgb(2, 112, 2);
+}

--- a/src/app/services/date-service.service.ts
+++ b/src/app/services/date-service.service.ts
@@ -19,6 +19,13 @@ export class DateServiceService {
         new Date(trans.due_date),
         {addSuffix: true}
       ), 
+      loanDue: this.loanDue(trans.due_date)
     }      
+  }
+
+  loanDue(dueDate: any): boolean {
+    const now = new Date();
+    const then = new Date(dueDate.toString());
+    return now >= then;
   }
 }

--- a/src/app/services/record.service.ts
+++ b/src/app/services/record.service.ts
@@ -40,6 +40,7 @@ export class RecordService {
 
   createRecord(info: any) {
     let formattedData = {
+      name: info.name,
       amount: info.amount,
       interest_rate: info.rate,
       description: info.desc,


### PR DESCRIPTION
based on the status of the loan record the record list cards displays a color
currently the available statuses are 
* active and
* due,

the peep function indicates 
* green for active records,
* red for due records

![localhost_8100_dashboard (2)](https://user-images.githubusercontent.com/29512699/94991633-e5d12900-0573-11eb-9bed-872e0fde52f1.png)
